### PR TITLE
Add Offset method for css parser

### DIFF
--- a/css/parse.go
+++ b/css/parse.go
@@ -142,7 +142,6 @@ func (p *Parser) Offset() int {
 	return p.l.r.Offset()
 }
 
-
 // Values returns a slice of Tokens for the last Grammar. Only AtRuleGrammar, BeginAtRuleGrammar, BeginRulesetGrammar and Declaration will return the at-rule components, ruleset selector and declaration values respectively.
 func (p *Parser) Values() []Token {
 	return p.buf

--- a/css/parse.go
+++ b/css/parse.go
@@ -137,7 +137,7 @@ func (p *Parser) Next() (GrammarType, TokenType, []byte) {
 	return gt, p.tt, p.data
 }
 
-// Return offset for current Grammar
+// Offset return offset for current Grammar
 func (p *Parser) Offset() int {
 	return p.l.r.Offset()
 }

--- a/css/parse.go
+++ b/css/parse.go
@@ -137,6 +137,12 @@ func (p *Parser) Next() (GrammarType, TokenType, []byte) {
 	return gt, p.tt, p.data
 }
 
+// Return offset for current Grammar
+func (p *Parser) Offset() int {
+	return p.l.r.Offset()
+}
+
+
 // Values returns a slice of Tokens for the last Grammar. Only AtRuleGrammar, BeginAtRuleGrammar, BeginRulesetGrammar and Declaration will return the at-rule components, ruleset selector and declaration values respectively.
 func (p *Parser) Values() []Token {
 	return p.buf


### PR DESCRIPTION
This can be used to calculate column or row if needed. Example (it is not using `parse.Position`, because it is "following" the parser, so no need each time calculate position from start):

```go

        var (
		bytesToLine []int
		cursorPos   int = 0
		cssLine     int = 0
	)

	lines := bytes.Split([]byte(inlineStyle), []byte("\n"))
	for _, line := range lines {
		bytesToLine = append(bytesToLine, cursorPos)
		cursorPos += len(line) + 1 // "\n" provide additional byte
	}

	getLineByOffset := func(offset int) int {
		for {
			if len(bytesToLine) <= cssLine {
				return cssLine
			}

			if bytesToLine[cssLine] > offset {
				return cssLine
			}

			cssLine += 1
		}
	}

	p := css.NewParser(parse.NewInput(bytes.NewBufferString(inlineStyle)), false)
	for {
		gt, _, data := p.Next()

		log.Printf("[CSS]: %v - %v - %v (line: %d)\n", gt, string(data), p.Values(), getLineByOffset(p.Offset()))

		if gt == css.ErrorGrammar {
			return
		}
      }
```